### PR TITLE
Fix build pipeline issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
     # - We use the *-latest runners because we strive to build with relatively
     #   new versions of each environment that have modern compilers (we need at
     #   least C++17, see CMakeLists.txt) and tools.
-    # - As of writing this all of the *-latest runners use CMake 3.19.1.
     # - The library should not only be cross-platform, it should also not rely
     #   on any particular compiler. On macOS the clang compiler is used
     #   (AppleClang), on Ubuntu the default is GNU GCC, and on Windows it's
@@ -47,15 +46,6 @@ jobs:
       run: |
         mkdir build
         cd build
-        # Setting CMAKE_SYSTEM_VERSION defines the Windows SDK that CMake should
-        # use for the build. We have to do this in order to override the
-        # Windows SDK that CMake would select on its own. The default Windows SDK
-        # on the windows-latest runner is currently 10.0.17763.0, and for unknown
-        # reasons that SDK version breaks the build. The symptoms are many C5105
-        # warnings, and eventually also some compiler errors. Windows SDK
-        # 10.0.18362.0 is a version that is known to work and that is also known
-        # to be installed on the windows-latest runner.
-        #cmake -DCMAKE_SYSTEM_VERSION="10.0.18362.0" ..
         cmake ..
       if: matrix.os == 'windows-latest'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
         # 10.0.18362.0 is a version that is known to work and that is also known
         # to be installed on the windows-latest runner.
         #cmake -DCMAKE_SYSTEM_VERSION="10.0.18362.0" ..
+        cmake ..
       if: matrix.os == 'windows-latest'
 
     - name: Build the project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,10 @@ jobs:
 
     steps:
     - name: Checking out the sources
-      uses: actions/checkout@v2
+      # @v4 refers to the Git tag "v4" in https://github.com/actions/checkout.
+      # The repo maintainers update the "v4" tag to always point to the latest
+      # v4 release of the checkout action.
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Release ..
       if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
 
-    - name: Generat build system (Windows)
+    - name: Generate build system (Windows)
       run: |
         mkdir build
         cd build
@@ -55,7 +55,7 @@ jobs:
         # warnings, and eventually also some compiler errors. Windows SDK
         # 10.0.18362.0 is a version that is known to work and that is also known
         # to be installed on the windows-latest runner.
-        cmake -DCMAKE_SYSTEM_VERSION="10.0.18362.0" ..
+        #cmake -DCMAKE_SYSTEM_VERSION="10.0.18362.0" ..
       if: matrix.os == 'windows-latest'
 
     - name: Build the project

--- a/src/SgfcUtility.cpp
+++ b/src/SgfcUtility.cpp
@@ -190,7 +190,7 @@ namespace LibSgfcPlusPlus
   std::string SgfcUtility::GetTempFolderPath()
   {
     std::filesystem::path tempFolderPath = std::filesystem::temp_directory_path();
-    return tempFolderPath;
+    return tempFolderPath.u8string();
   }
 
   std::string SgfcUtility::GetUniqueTempFileName()

--- a/src/SgfcUtility.h
+++ b/src/SgfcUtility.h
@@ -155,8 +155,9 @@ namespace LibSgfcPlusPlus
     /// SgfcPrivateConstants::ArgumentTypeToCmdlineOptionMap.
     static std::string MapArgumentTypeToCmdlineOption(SgfcArgumentType argumentType);
 
-    /// @brief Returns the full path to a folder that is suitable for temporary
-    /// files. The path is guaranteed to exist and to be a directory.
+    /// @brief Returns the full path of a folder that is suitable for temporary
+    /// files. The path is guaranteed to exist and to be a directory. The
+    /// returned path string is UTF-8 encoded.
     ///
     /// The implementation makes use of std::filesystem::temp_directory_path(),
     /// which is defined in C++17 but may not be available on older platform
@@ -182,9 +183,10 @@ namespace LibSgfcPlusPlus
     ///   file
     static std::string GetUniqueTempFileName();
 
-    /// @brief Returns the unique absolute path name of a file that is extremely
+    /// @brief Returns the unique absolute path of a file that is extremely
     /// unlikely to already exist in the temporary folder returned by
-    /// GetTempPath(). This method never returns the same value twice.
+    /// GetTempPath(). The returned path string is UTF-8 encoded. This method
+    /// never returns the same value twice.
     ///
     /// This is a convenience function that invokes JoinPathComponents() using
     /// the return values of GetTempFolderPath() and GetUniqueTempFileName().


### PR DESCRIPTION
- update to latest version of checkout action
- remove explicit selection of Windows SDK
- make conversion of std::filesystem:path to std::string explicit (fixes Visual Studio build error)
- cleanup build.yml